### PR TITLE
Feat/#8-5: 이벤트 스케줄러 구현

### DIFF
--- a/src/main/java/com/project/likelion13th_team1/Likelion13thTeam1Application.java
+++ b/src/main/java/com/project/likelion13th_team1/Likelion13thTeam1Application.java
@@ -3,9 +3,11 @@ package com.project.likelion13th_team1;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class Likelion13thTeam1Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/project/likelion13th_team1/domain/event/scheduler/EventScheduler.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/event/scheduler/EventScheduler.java
@@ -1,0 +1,64 @@
+package com.project.likelion13th_team1.domain.event.scheduler;
+
+import com.project.likelion13th_team1.domain.event.converter.EventConverter;
+import com.project.likelion13th_team1.domain.event.entity.Event;
+import com.project.likelion13th_team1.domain.event.repository.EventRepository;
+import com.project.likelion13th_team1.domain.routine.entity.Routine;
+import com.project.likelion13th_team1.domain.routine.repository.RoutineRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventScheduler {
+
+    private final RoutineRepository routineRepository;
+    private final EventRepository eventRepository;
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정
+//    @Scheduled(fixedRate = 10000)
+    public void generateRoutineEvents() {
+        log.info("[Scheduler] 루틴 이벤트 생성 스케줄러 시작");
+        LocalDate today = LocalDate.now();
+        LocalDate yearLater = today.plusYears(1); // ✅ 생성 범위: 오늘 ~ 1년 뒤
+
+        List<Routine> routines = routineRepository.findAllActiveRoutines(); // ✅ 활성 루틴만
+
+        for (Routine routine : routines) {
+            LocalDate start = routine.getStartAt();
+            LocalDate end = routine.getEndAt() != null ? routine.getEndAt() : yearLater;
+            long cycle = routine.getCycle().getDays(); // ✅ 예: 3일마다
+
+            // endAt이 1년 뒤보다 늦으면 1년 뒤까지만 생성
+            LocalDate generateUntil = end.isBefore(yearLater) ? end : yearLater;
+
+            // ✅ 이미 생성된 날짜 추출
+            Set<LocalDate> existingDates = new HashSet<>(
+                    eventRepository.findScheduledDatesByRoutineAndStartBetweenEnd(routine, today, generateUntil)
+            );
+
+            List<Event> eventsToSave = new ArrayList<>();
+
+            for (LocalDate date = start; !date.isAfter(generateUntil); date = date.plusDays(cycle)) {
+                if (!date.isBefore(today) && !existingDates.contains(date)) {
+                    Event event = EventConverter.toEvent(routine, date);
+                    eventsToSave.add(event);
+                    log.info("✅ 이벤트 생성 - routineId={}, date={}", routine.getId(), date);
+                }
+            }
+
+            eventRepository.saveAll(eventsToSave);
+        }
+
+        log.info("[Scheduler] 루틴 이벤트 생성 스케줄러 종료");
+    }
+}

--- a/src/main/java/com/project/likelion13th_team1/domain/event/service/command/EventCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/event/service/command/EventCommandServiceImpl.java
@@ -32,16 +32,17 @@ public class EventCommandServiceImpl implements EventCommandService {
     public int createEvent(Routine routine) {
 
         LocalDate start = routine.getStartAt();
-        LocalDate end = routine.getEndAt();
+        LocalDate oneYearLater = start.plusYears(1);
+        LocalDate end;
+
+        if (routine.getEndAt() != null && routine.getEndAt().isBefore(oneYearLater)) {
+            end = routine.getEndAt();
+        } else {
+            end = oneYearLater;
+        }
+
         long cycle = routine.getCycle().getDays();
         int eventCount = 0;
-
-//        // 루틴 반복 시작 시간과 반복 끝 시간이 며칠인지 계산 후, cycle이 몇 번 들어갈 수 있는지 확인후 생성
-//        for (LocalDateTime date = start; !date.isAfter(end); date = date.plusDays(cycle)) {
-//            Event event = EventConverter.toEvent(routine, date);
-//            eventRepository.save(event);
-//            eventCount++;
-//        }
 
         Set<LocalDate> existingDates = new HashSet<>(
                 eventRepository.findScheduledDatesByRoutineAndStartBetweenEnd(routine, start, end)
@@ -63,12 +64,11 @@ public class EventCommandServiceImpl implements EventCommandService {
             if (!existingDates.contains(date)) {
                 Event event = EventConverter.toEvent(routine, date);
                 eventsToSave.add(event);
-
                 eventCount++;
             }
         }
-        eventRepository.saveAll(eventsToSave);
 
+        eventRepository.saveAll(eventsToSave);
         return eventCount;
     }
 

--- a/src/main/java/com/project/likelion13th_team1/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/routine/controller/RoutineController.java
@@ -24,7 +24,12 @@ public class RoutineController {
     private final RoutineCommandService routineCommandService;
     private final RoutineQueryService routineQueryService;
 
-    @Operation(summary = "루틴 생성", description = "루틴 이름, 루틴 설명, 시작 시간은 빈칸일 수 없다.<br>status는 루틴의 상태를 말하며, PROCESSING, SUCCESS가 있다. <br> cycle은 주기로 NO, DAY, WEEK, MONTH, YEAR이 있다. <br> cycle이 no인 경우에는 endAt은 null")
+    @Operation(summary = "루틴 생성",
+            description = "루틴 이름, 루틴 설명, 시작 시간은 빈칸일 수 없다." +
+            "<br>status는 루틴의 상태를 말하며, PROCESSING, SUCCESS가 있다. " +
+            "<br> cycle은 주기로 NO, DAY, WEEK, MONTH, YEAR이 있다. " +
+            "<br> cycle이 no인 경우에는 endAt은 null" +
+            "<br> 1년을 넘는 범위로 설정하면, 이벤트는 현재 시간으로부터 1년까지만 생성되고 날짜가 지남에 따라 매일 자정에 자동 추가 생성된다.")
     @PostMapping("/group/{groupId}/routines")
     public CustomResponse<RoutineResponseDto.RoutineCreateResponseDto> createRoutine(
             @PathVariable Long groupId,

--- a/src/main/java/com/project/likelion13th_team1/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/routine/repository/RoutineRepository.java
@@ -30,4 +30,9 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
             @Param("cursor") Long cursor,
             Pageable pageable
     );
+
+    @Query("SELECT r " +
+            "FROM Routine r " +
+            "WHERE r.isActive = true")
+    List<Routine> findAllActiveRoutines();
 }


### PR DESCRIPTION
# ☝️Issue Number

- #8 

##  📌 개요

- 이벤트 스케줄러 구현
- 이벤트는 현재 서버 시간으로부터 1년까지만 생성된다
- 만약 endAt이 1년을 초과하는 범위라면, 서버 시간이 지남에 따라 자동으로 자정에 이벤트가 생성된다. (Sliding Window)

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점