### PR TITLE
Feat/#14-4 카카오 로그인 구현

### DIFF
--- a/src/main/java/com/project/likelion13th_team1/domain/feature/converter/FeatureConverter.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/feature/converter/FeatureConverter.java
@@ -3,15 +3,17 @@ package com.project.likelion13th_team1.domain.feature.converter;
 import com.project.likelion13th_team1.domain.feature.dto.request.FeatureRequestDto;
 import com.project.likelion13th_team1.domain.feature.dto.response.FeatureResponseDto;
 import com.project.likelion13th_team1.domain.feature.entity.Feature;
+import com.project.likelion13th_team1.domain.member.entity.Member;
 
 public class FeatureConverter {
 
-    public static Feature toFeature(FeatureRequestDto.FeatureCreateRequestDto dto) {
+    public static Feature toFeature(FeatureRequestDto.FeatureCreateRequestDto dto, Member member) {
         return Feature.builder()
                 .q1(dto.q1())
                 .q2(dto.q2())
                 .q3(dto.q3())
                 .q4(dto.q4())
+                .member(member)
                 .build();
     }
 

--- a/src/main/java/com/project/likelion13th_team1/domain/feature/entity/Feature.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/feature/entity/Feature.java
@@ -1,6 +1,7 @@
 package com.project.likelion13th_team1.domain.feature.entity;
 
 
+import com.project.likelion13th_team1.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -30,6 +31,10 @@ public class Feature {
 
     @Column(name = "Q4")
     private Integer q4;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
 
     public void updateQ1(Integer q1) {

--- a/src/main/java/com/project/likelion13th_team1/domain/feature/repository/FeatureRepository.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/feature/repository/FeatureRepository.java
@@ -1,7 +1,12 @@
 package com.project.likelion13th_team1.domain.feature.repository;
 
 import com.project.likelion13th_team1.domain.feature.entity.Feature;
+import com.project.likelion13th_team1.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FeatureRepository extends JpaRepository<Feature, Long> {
+
+    Optional<Feature> findByMember(Member member);
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/feature/service/command/FeatureCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/feature/service/command/FeatureCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.likelion13th_team1.domain.feature.service.command;
 
+import com.project.likelion13th_team1.domain.feature.dto.response.FeatureResponseDto;
 import com.project.likelion13th_team1.domain.member.entity.Member;
 import com.project.likelion13th_team1.domain.member.exception.MemberErrorCode;
 import com.project.likelion13th_team1.domain.member.exception.MemberException;
@@ -24,11 +25,11 @@ public class FeatureCommandServiceImpl implements FeatureCommandService {
 
     @Override
     public void createFeature(String email, FeatureRequestDto.FeatureCreateRequestDto featureCreateRequestDto) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         // TODO : 중복저장 방지
-        Feature feature = FeatureConverter.toFeature(featureCreateRequestDto);
+        Feature feature = FeatureConverter.toFeature(featureCreateRequestDto, member);
         featureRepository.save(feature);
 
         member.linkFeature(feature);
@@ -36,13 +37,11 @@ public class FeatureCommandServiceImpl implements FeatureCommandService {
 
     @Override
     public void updateFeature(String email, FeatureRequestDto.FeatureUpdateRequestDto featureUpdateRequestDto) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        Feature feature = member.getFeature();
-        if(feature == null) {
-            throw new FeatureException(FeatureErrorCode.FEATURE_NOT_FOUND);
-        }
+        Feature feature = featureRepository.findByMember(member)
+                .orElseThrow(() -> new FeatureException(FeatureErrorCode.FEATURE_NOT_FOUND));
 
         if (featureUpdateRequestDto.q1() != null) feature.updateQ1(featureUpdateRequestDto.q1());
         if (featureUpdateRequestDto.q2() != null) feature.updateQ2(featureUpdateRequestDto.q2());

--- a/src/main/java/com/project/likelion13th_team1/domain/feature/service/query/FeatureQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/feature/service/query/FeatureQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.likelion13th_team1.domain.feature.service.query;
 
+import com.project.likelion13th_team1.domain.feature.repository.FeatureRepository;
 import com.project.likelion13th_team1.domain.member.entity.Member;
 import com.project.likelion13th_team1.domain.member.exception.MemberErrorCode;
 import com.project.likelion13th_team1.domain.member.exception.MemberException;
@@ -19,16 +20,15 @@ import org.springframework.stereotype.Service;
 public class FeatureQueryServiceImpl implements FeatureQueryService {
 
     private final MemberRepository memberRepository;
+    private final FeatureRepository featureRepository;
 
     @Override
     public FeatureResponseDto.FeatureDetailResponseDto getFeature(String email) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        Feature feature = member.getFeature();
-        if(feature == null) {
-            throw new FeatureException(FeatureErrorCode.FEATURE_NOT_FOUND);
-        }
+        Feature feature = featureRepository.findByMember(member)
+                .orElseThrow(() -> new FeatureException(FeatureErrorCode.FEATURE_NOT_FOUND));
         return FeatureConverter.toFeatureDetailResponseDto(feature);
     }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/group/service/command/GroupCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/group/service/command/GroupCommandServiceImpl.java
@@ -31,7 +31,7 @@ public class GroupCommandServiceImpl implements GroupCommandService {
 
     @Override
     public GroupResponseDto.GroupCreateResponseDto createGroup(String email, GroupRequestDto.GroupCreateRequestDto groupCreateRequestDto) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Group group = GroupConverter.toGroup(groupCreateRequestDto, member);
@@ -43,7 +43,7 @@ public class GroupCommandServiceImpl implements GroupCommandService {
 
     @Override
     public void updateGroup(String email, Long groupId, GroupRequestDto.GroupUpdateRequestDto groupUpdateRequestDto) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Group group = groupRepository.findById(groupId)
@@ -54,7 +54,7 @@ public class GroupCommandServiceImpl implements GroupCommandService {
 
     @Override
     public void deleteGroup(String email, Long groupId) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Group group = groupRepository.findById(groupId)

--- a/src/main/java/com/project/likelion13th_team1/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/controller/MemberController.java
@@ -25,10 +25,10 @@ public class MemberController {
 
     @Operation(summary = "회원가입", description = "유저이름이 공백이면 안됨<br/>이메일 형식을 지켜야함<br/>비밀번호는 문자, 숫자, 특수문자를 포함한 8자 이상")
     @PostMapping("/signup")
-    public CustomResponse<String> createMember(
+    public CustomResponse<String> createLocalMember(
             @RequestBody @Valid MemberRequestDto.MemberCreateRequestDto memberCreateRequestDto
     ) {
-        memberCommandService.createMember(memberCreateRequestDto);
+        memberCommandService.createLocalMember(memberCreateRequestDto);
         return CustomResponse.onSuccess(HttpStatus.CREATED, "회원 가입 성공");
     }
 

--- a/src/main/java/com/project/likelion13th_team1/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/converter/MemberConverter.java
@@ -11,11 +11,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberConverter {
 
-    public static Member toMember(MemberRequestDto.MemberCreateRequestDto dto, String password) {
+    public static Member toMember(MemberRequestDto.MemberCreateRequestDto dto) {
         return Member.builder()
                 .username(dto.username())
                 .email(dto.email())
-                .password(password)
+//                .password(password)
                 .role(Role.USER)
                 .socialType(SocialType.LOCAL)
                 .build();

--- a/src/main/java/com/project/likelion13th_team1/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/converter/MemberConverter.java
@@ -5,6 +5,7 @@ import com.project.likelion13th_team1.domain.member.dto.response.MemberResponseD
 import com.project.likelion13th_team1.domain.member.entity.Member;
 import com.project.likelion13th_team1.domain.member.entity.Role;
 import com.project.likelion13th_team1.domain.member.entity.SocialType;
+import com.project.likelion13th_team1.global.security.kakao.dto.response.KakaoUserInfoResponseDto;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +22,15 @@ public class MemberConverter {
                 .build();
     }
 
+    public static Member toMember(MemberRequestDto.MemberSocialCreateRequestDto dto){
+        return Member.builder()
+                .username(dto.username())
+                .email(dto.email())
+                .role(Role.USER)
+                .socialType(dto.socialType())
+                .build();
+    }
+
     public static MemberResponseDto.MemberDetailResponseDto toMemberDetailResponseDto(Member member) {
         return MemberResponseDto.MemberDetailResponseDto.builder()
                 .username(member.getUsername())
@@ -29,6 +39,16 @@ public class MemberConverter {
                 .socialType(member.getSocialType())
                 .createdAt(member.getCreatedAt())
                 .updatedAt(member.getUpdatedAt())
+                .build();
+    }
+
+    public static MemberRequestDto.MemberSocialCreateRequestDto toMemberSocialCreateRequestDto(KakaoUserInfoResponseDto userInfo) {
+        return MemberRequestDto.MemberSocialCreateRequestDto.builder()
+                .username(userInfo.kakaoAccount().profile().nickName())
+                .email(userInfo.kakaoAccount().email())
+                .socialId(userInfo.id())
+                .profileImage(userInfo.kakaoAccount().profile().profileImageUrl())
+                .socialType(SocialType.KAKAO)
                 .build();
     }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/member/converter/SocialLoginConverter.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/converter/SocialLoginConverter.java
@@ -1,0 +1,19 @@
+package com.project.likelion13th_team1.domain.member.converter;
+
+import com.project.likelion13th_team1.domain.member.dto.request.MemberRequestDto;
+import com.project.likelion13th_team1.domain.member.entity.Member;
+import com.project.likelion13th_team1.domain.member.entity.SocialLogin;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SocialLoginConverter {
+
+    public static SocialLogin toSocialLogin(MemberRequestDto.MemberSocialCreateRequestDto dto, Member member) {
+        return SocialLogin.builder()
+                .socialId(dto.socialId())
+                .member(member)
+                .socialType(dto.socialType())
+                .build();
+    }
+}

--- a/src/main/java/com/project/likelion13th_team1/domain/member/dto/request/MemberRequestDto.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/dto/request/MemberRequestDto.java
@@ -1,5 +1,6 @@
 package com.project.likelion13th_team1.domain.member.dto.request;
 
+import com.project.likelion13th_team1.domain.member.entity.SocialType;
 import com.project.likelion13th_team1.global.security.utils.PasswordPattern;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -25,5 +26,15 @@ public class MemberRequestDto {
             String profileImage
             //TODO : 유저 특성도 이걸로 바꿀건지?
     ){
+    }
+
+    @Builder
+    public record MemberSocialCreateRequestDto(
+            String username,
+            String email,
+            String profileImage,
+            Long socialId,
+            SocialType socialType
+    ) {
     }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/member/entity/Member.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.project.likelion13th_team1.domain.member.entity;
 import com.project.likelion13th_team1.domain.member.dto.request.MemberRequestDto;
 import com.project.likelion13th_team1.global.entity.BaseEntity;
 import com.project.likelion13th_team1.domain.feature.entity.Feature;
+import com.project.likelion13th_team1.global.security.auth.entity.Auth;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -29,9 +30,9 @@ public class Member extends BaseEntity {
     @Column(name = "email", nullable = false, unique = true)
     private String email;
 
-    // 비밀번호
-    @Column(name = "password", nullable = false)
-    private String password;
+//    // 비밀번호
+//    @Column(name = "password", nullable = false)
+//    private String password;
 
     // 프로필 사진
     @Column(name = "profile_image")
@@ -55,6 +56,9 @@ public class Member extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feature_id", unique = true)
     private Feature feature;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Auth auth;
 
     // feature 생성 후 연결 메서드
     // TODO : 이 연결 메서드를 제네릭으로 한다면!! Routine에서 재활용할 수 있지 않을까요

--- a/src/main/java/com/project/likelion13th_team1/domain/member/entity/Member.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.project.likelion13th_team1.domain.member.entity;
 
+import com.project.likelion13th_team1.domain.group.entity.Group;
 import com.project.likelion13th_team1.domain.member.dto.request.MemberRequestDto;
 import com.project.likelion13th_team1.global.entity.BaseEntity;
 import com.project.likelion13th_team1.domain.feature.entity.Feature;
@@ -8,6 +9,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -53,12 +55,15 @@ public class Member extends BaseEntity {
     private LocalDateTime deletedAt;
 
     // 루틴 추천을 위한 멤버의 특성
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "feature_id", unique = true)
     private Feature feature;
 
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Auth auth;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Group> group;
 
     // feature 생성 후 연결 메서드
     // TODO : 이 연결 메서드를 제네릭으로 한다면!! Routine에서 재활용할 수 있지 않을까요

--- a/src/main/java/com/project/likelion13th_team1/domain/member/entity/SocialLogin.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/entity/SocialLogin.java
@@ -1,0 +1,27 @@
+package com.project.likelion13th_team1.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "social_login")
+public class SocialLogin {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "social_id", nullable = false)
+    private Long socialId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "social_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+}

--- a/src/main/java/com/project/likelion13th_team1/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/repository/MemberRepository.java
@@ -2,10 +2,17 @@ package com.project.likelion13th_team1.domain.member.repository;
 
 import com.project.likelion13th_team1.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    @Query("SELECT m " +
+            "FROM Member m " +
+            "WHERE m.email = :email AND m.deletedAt IS NULL")
+    Optional<Member> findByEmailAndNotDeleted(@Param("email") String email);
 
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/member/repository/SocialLoginRepository.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/repository/SocialLoginRepository.java
@@ -1,0 +1,7 @@
+package com.project.likelion13th_team1.domain.member.repository;
+
+import com.project.likelion13th_team1.domain.member.entity.SocialLogin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SocialLoginRepository extends JpaRepository<SocialLogin, Long> {
+}

--- a/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandService.java
@@ -3,7 +3,7 @@ package com.project.likelion13th_team1.domain.member.service.command;
 import com.project.likelion13th_team1.domain.member.dto.request.MemberRequestDto;
 
 public interface MemberCommandService {
-    void createMember(MemberRequestDto.MemberCreateRequestDto memberCreateRequestDto);
+    void createLocalMember(MemberRequestDto.MemberCreateRequestDto memberCreateRequestDto);
 
     void updateMember(String email, MemberRequestDto.MemberUpdateRequestDto memberUpdateRequestDto);
 

--- a/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandService.java
@@ -5,6 +5,8 @@ import com.project.likelion13th_team1.domain.member.dto.request.MemberRequestDto
 public interface MemberCommandService {
     void createLocalMember(MemberRequestDto.MemberCreateRequestDto memberCreateRequestDto);
 
+    void createSocialMember(MemberRequestDto.MemberSocialCreateRequestDto memberSocialCreateRequestDto);
+
     void updateMember(String email, MemberRequestDto.MemberUpdateRequestDto memberUpdateRequestDto);
 
     void deleteMember(String email);

--- a/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandServiceImpl.java
@@ -4,13 +4,10 @@ import com.project.likelion13th_team1.domain.member.converter.MemberConverter;
 import com.project.likelion13th_team1.domain.member.converter.SocialLoginConverter;
 import com.project.likelion13th_team1.domain.member.dto.request.MemberRequestDto;
 import com.project.likelion13th_team1.domain.member.entity.Member;
-import com.project.likelion13th_team1.domain.member.entity.Role;
 import com.project.likelion13th_team1.domain.member.entity.SocialLogin;
-import com.project.likelion13th_team1.domain.member.entity.SocialType;
 import com.project.likelion13th_team1.domain.member.exception.MemberErrorCode;
 import com.project.likelion13th_team1.domain.member.exception.MemberException;
 import com.project.likelion13th_team1.domain.member.repository.MemberRepository;
-import com.project.likelion13th_team1.domain.feature.repository.FeatureRepository;
 import com.project.likelion13th_team1.domain.member.repository.SocialLoginRepository;
 import com.project.likelion13th_team1.global.security.auth.converter.AuthConverter;
 import com.project.likelion13th_team1.global.security.auth.entity.Auth;
@@ -61,7 +58,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     public void updateMember(String email, MemberRequestDto.MemberUpdateRequestDto dto) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         member.updateUsername(dto);
@@ -69,10 +66,11 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     public void deleteMember(String email) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        // soft delete
-        member.delete();
+//        // soft delete
+//        member.delete();
+        memberRepository.delete(member);
     }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandServiceImpl.java
@@ -7,6 +7,9 @@ import com.project.likelion13th_team1.domain.member.exception.MemberErrorCode;
 import com.project.likelion13th_team1.domain.member.exception.MemberException;
 import com.project.likelion13th_team1.domain.member.repository.MemberRepository;
 import com.project.likelion13th_team1.domain.feature.repository.FeatureRepository;
+import com.project.likelion13th_team1.global.security.auth.converter.AuthConverter;
+import com.project.likelion13th_team1.global.security.auth.entity.Auth;
+import com.project.likelion13th_team1.global.security.auth.repository.AuthRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -20,21 +23,21 @@ import org.springframework.stereotype.Service;
 public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final MemberRepository memberRepository;
-    private final FeatureRepository featureRepository;
+    private final AuthRepository authRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
     @Override
-    public void createMember(MemberRequestDto.MemberCreateRequestDto dto) {
+    public void createLocalMember(MemberRequestDto.MemberCreateRequestDto dto) {
         // TODO : 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(dto.password());
-        Member member = MemberConverter.toMember(dto, encodedPassword);
-
+        Member member = MemberConverter.toMember(dto);
+        Auth auth = AuthConverter.toAuth(encodedPassword, member);
         try {
             memberRepository.save(member);
+            authRepository.save(auth);
         } catch (DataIntegrityViolationException e) {
             throw new MemberException(MemberErrorCode.MEMBER_EMAIL_DUPLICATE);
         }
-
     }
 
     @Override

--- a/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandServiceImpl.java
@@ -1,12 +1,17 @@
 package com.project.likelion13th_team1.domain.member.service.command;
 
 import com.project.likelion13th_team1.domain.member.converter.MemberConverter;
+import com.project.likelion13th_team1.domain.member.converter.SocialLoginConverter;
 import com.project.likelion13th_team1.domain.member.dto.request.MemberRequestDto;
 import com.project.likelion13th_team1.domain.member.entity.Member;
+import com.project.likelion13th_team1.domain.member.entity.Role;
+import com.project.likelion13th_team1.domain.member.entity.SocialLogin;
+import com.project.likelion13th_team1.domain.member.entity.SocialType;
 import com.project.likelion13th_team1.domain.member.exception.MemberErrorCode;
 import com.project.likelion13th_team1.domain.member.exception.MemberException;
 import com.project.likelion13th_team1.domain.member.repository.MemberRepository;
 import com.project.likelion13th_team1.domain.feature.repository.FeatureRepository;
+import com.project.likelion13th_team1.domain.member.repository.SocialLoginRepository;
 import com.project.likelion13th_team1.global.security.auth.converter.AuthConverter;
 import com.project.likelion13th_team1.global.security.auth.entity.Auth;
 import com.project.likelion13th_team1.global.security.auth.repository.AuthRepository;
@@ -25,6 +30,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final MemberRepository memberRepository;
     private final AuthRepository authRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final SocialLoginRepository socialLoginRepository;
 
     @Override
     public void createLocalMember(MemberRequestDto.MemberCreateRequestDto dto) {
@@ -35,6 +41,19 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         try {
             memberRepository.save(member);
             authRepository.save(auth);
+        } catch (DataIntegrityViolationException e) {
+            throw new MemberException(MemberErrorCode.MEMBER_EMAIL_DUPLICATE);
+        }
+    }
+
+    @Override
+    public void createSocialMember(MemberRequestDto.MemberSocialCreateRequestDto dto) {
+
+        Member member = MemberConverter.toMember(dto);
+        SocialLogin socialLogin = SocialLoginConverter.toSocialLogin(dto, member);
+        try {
+            memberRepository.save(member);
+            socialLoginRepository.save(socialLogin);
         } catch (DataIntegrityViolationException e) {
             throw new MemberException(MemberErrorCode.MEMBER_EMAIL_DUPLICATE);
         }

--- a/src/main/java/com/project/likelion13th_team1/domain/member/service/query/MemberQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/service/query/MemberQueryServiceImpl.java
@@ -19,7 +19,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
     @Override
     public MemberResponseDto.MemberDetailResponseDto getMember(String email) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         return MemberConverter.toMemberDetailResponseDto(member);

--- a/src/main/java/com/project/likelion13th_team1/domain/routine/service/command/RoutineCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/routine/service/command/RoutineCommandServiceImpl.java
@@ -51,7 +51,7 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
     @Override
     public RoutineResponseDto.RoutineUpdateResponseDto updateRoutine(String email, Long routineId, RoutineRequestDto.RoutineUpdateRequestDto routineUpdateRequestDto) {
         // TODO : update랑 delete 공통 부분을 private method로 묶기?
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Routine routine = routineRepository.findById(routineId)
@@ -70,7 +70,7 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
     // TODO : 스케줄러 구현하기
     @Override
     public void deleteRoutine(String email, Long routineId) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Routine routine = routineRepository.findById(routineId)
@@ -86,7 +86,7 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
 
     @Override
     public void activateRoutine(String email, Long routineId) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Routine routine = routineRepository.findById(routineId)
@@ -103,7 +103,7 @@ public class RoutineCommandServiceImpl implements RoutineCommandService {
 
     @Override
     public void inactivateRoutine(String email, Long routineId) {
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Routine routine = routineRepository.findById(routineId)

--- a/src/main/java/com/project/likelion13th_team1/global/security/auth/converter/AuthConverter.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/auth/converter/AuthConverter.java
@@ -1,0 +1,14 @@
+package com.project.likelion13th_team1.global.security.auth.converter;
+
+import com.project.likelion13th_team1.domain.member.entity.Member;
+import com.project.likelion13th_team1.global.security.auth.entity.Auth;
+
+public class AuthConverter {
+
+    public static Auth toAuth(String password, Member member) {
+        return Auth.builder()
+                .member(member)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/project/likelion13th_team1/global/security/auth/entity/Auth.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/auth/entity/Auth.java
@@ -1,0 +1,25 @@
+package com.project.likelion13th_team1.global.security.auth.entity;
+
+import com.project.likelion13th_team1.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "auth")
+public class Auth {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", unique = true, nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/project/likelion13th_team1/global/security/auth/repository/AuthRepository.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/auth/repository/AuthRepository.java
@@ -1,0 +1,12 @@
+package com.project.likelion13th_team1.global.security.auth.repository;
+
+import com.project.likelion13th_team1.domain.member.entity.Member;
+import com.project.likelion13th_team1.global.security.auth.entity.Auth;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AuthRepository extends JpaRepository<Auth, Long> {
+
+    Optional<Auth> findByMember(Member member);
+}

--- a/src/main/java/com/project/likelion13th_team1/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
             "/api/v1/auth/login", //로그인 은 인증이 필요하지 않음
             "/api/v1/members/signup", // 회원가입은 인증이 필요하지 않음
             "/api/v1/auth/reissue", // 토큰 재발급은 인증이 필요하지 않음
+            "/api/v1/callback/kakao",
             "api/usage",
             "/swagger-ui/**",   // swagger 관련 URL
             "/v3/api-docs/**",

--- a/src/main/java/com/project/likelion13th_team1/global/security/kakao/controller/KakaoLoginController.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/kakao/controller/KakaoLoginController.java
@@ -50,9 +50,11 @@ public class KakaoLoginController {
 
         // 3. 회원가입 & 로그인 처리
         // 여기에 서버 사용자 로그인(인증) 또는 회원가입 로직 추가
-        Optional<Member> member = memberRepository.findByEmail(userInfo.kakaoAccount().email());
-
         log.info("email = {}", userInfo.kakaoAccount().email());
+        Optional<Member> member = memberRepository.findByEmailAndNotDeleted(userInfo.kakaoAccount().email());
+
+
+
 
         if (member.isEmpty()) {
             // 존재하지 않으니 회원가입으로 이동

--- a/src/main/java/com/project/likelion13th_team1/global/security/kakao/controller/KakaoLoginController.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/kakao/controller/KakaoLoginController.java
@@ -1,0 +1,78 @@
+package com.project.likelion13th_team1.global.security.kakao.controller;
+
+import com.project.likelion13th_team1.domain.member.converter.MemberConverter;
+import com.project.likelion13th_team1.domain.member.dto.request.MemberRequestDto;
+import com.project.likelion13th_team1.domain.member.entity.Member;
+import com.project.likelion13th_team1.domain.member.entity.Role;
+import com.project.likelion13th_team1.domain.member.repository.MemberRepository;
+import com.project.likelion13th_team1.domain.member.service.command.MemberCommandService;
+import com.project.likelion13th_team1.global.apiPayload.CustomResponse;
+import com.project.likelion13th_team1.global.security.jwt.JwtUtil;
+import com.project.likelion13th_team1.global.security.jwt.dto.JwtDto;
+import com.project.likelion13th_team1.global.security.kakao.dto.response.KakaoUserInfoResponseDto;
+import com.project.likelion13th_team1.global.security.kakao.service.KakaoService;
+import com.project.likelion13th_team1.global.security.userdetails.CustomUserDetails;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@Tag(name = "Kakao", description = "카카오 로그인 컨트롤러")
+public class KakaoLoginController {
+
+    private final KakaoService kakaoService;
+    private final MemberRepository memberRepository;
+    private final MemberCommandService memberCommandService;
+    private final JwtUtil jwtUtil;
+
+    @GetMapping("/callback/kakao")
+    public CustomResponse<JwtDto> callback(
+            @RequestParam("code") String code
+
+    ) {
+
+        // 1. 카카오 인증서버에서 토큰을 발급받는다.
+        // 인가code와 Redirect URL을 파라미터로 전달하여 카카오 인증서버에 요청.
+        String accessToken = kakaoService.getAccessTokenFromKakao(code);
+
+
+        // 2. 1번에서 받은 토큰으로 카카오 리소스 서버에 사용자 정보 요청.
+        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(accessToken);
+
+        // 3. 회원가입 & 로그인 처리
+        // 여기에 서버 사용자 로그인(인증) 또는 회원가입 로직 추가
+        Optional<Member> member = memberRepository.findByEmail(userInfo.kakaoAccount().email());
+
+        log.info("email = {}", userInfo.kakaoAccount().email());
+
+        if (member.isEmpty()) {
+            // 존재하지 않으니 회원가입으로 이동
+            log.info("[ KakaoLoginController ] 회원이 아닙니다. 회원 가입을 먼저 진행합니다");
+            MemberRequestDto.MemberSocialCreateRequestDto memberSocialCreateRequestDto =
+                    MemberConverter.toMemberSocialCreateRequestDto(userInfo);
+
+            memberCommandService.createSocialMember(memberSocialCreateRequestDto);
+        }
+        // 로그인으로 이동
+        log.info("[ KakaoLoginController ] 회원 정보가 존재해 로그인을 진행합니다");
+        CustomUserDetails customUserDetails = new CustomUserDetails(userInfo.kakaoAccount().email(), null, Role.USER);
+
+        //Client 에게 줄 Response 를 Build
+        JwtDto jwtDto = JwtDto.builder()
+                .accessToken(jwtUtil.createJwtAccessToken(customUserDetails)) //access token 생성
+                .refreshToken(jwtUtil.createJwtRefreshToken(customUserDetails)) //refresh token 생성
+                .build();
+
+        // CustomResponse 사용하여 응답 통일
+        return CustomResponse.onSuccess(jwtDto);
+    }
+}

--- a/src/main/java/com/project/likelion13th_team1/global/security/kakao/dto/response/KakaoTokenResponseDto.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/kakao/dto/response/KakaoTokenResponseDto.java
@@ -1,0 +1,26 @@
+package com.project.likelion13th_team1.global.security.kakao.dto.response;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoTokenResponseDto (
+        @JsonProperty("token_type")
+        String tokenType,
+        @JsonProperty("access_token")
+        String accessToken,
+        @JsonProperty("id_token")
+        String idToken,
+        @JsonProperty("expires_in")
+        Integer expiresIn,
+        @JsonProperty("refresh_token")
+        String refreshToken,
+        @JsonProperty("refresh_token_expires_in")
+        Integer refreshTokenExpiresIn,
+        @JsonProperty("scope")
+        String scope
+) {
+}

--- a/src/main/java/com/project/likelion13th_team1/global/security/kakao/dto/response/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/kakao/dto/response/KakaoUserInfoResponseDto.java
@@ -1,0 +1,178 @@
+package com.project.likelion13th_team1.global.security.kakao.dto.response;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+import java.util.HashMap;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserInfoResponseDto(
+        //회원 번호
+        @JsonProperty("id")
+        Long id,
+
+        //자동 연결 설정을 비활성화한 경우만 존재.
+        //true : 연결 상태, false : 연결 대기 상태
+        @JsonProperty("has_signed_up")
+        Boolean hasSignedUp,
+
+        //서비스에 연결 완료된 시각. UTC
+        @JsonProperty("connected_at")
+        Date connectedAt,
+
+        //카카오싱크 간편가입을 통해 로그인한 시각. UTC
+        @JsonProperty("synched_at")
+        Date synchedAt,
+
+        //사용자 프로퍼티
+        @JsonProperty("properties")
+        HashMap<String, String> properties,
+
+        //카카오 계정 정보
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount,
+
+        //uuid 등 추가 정보
+        @JsonProperty("for_partner")
+        Partner partner
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record KakaoAccount(
+            //프로필 정보 제공 동의 여부
+            @JsonProperty("profile_needs_agreement")
+            Boolean isProfileAgree,
+
+            //닉네임 제공 동의 여부
+            @JsonProperty("profile_nickname_needs_agreement")
+            Boolean isNickNameAgree,
+
+            //프로필 사진 제공 동의 여부
+            @JsonProperty("profile_image_needs_agreement")
+            Boolean isProfileImageAgree,
+
+            //사용자 프로필 정보
+            @JsonProperty("profile")
+            Profile profile,
+
+            //이름 제공 동의 여부
+            @JsonProperty("name_needs_agreement")
+            Boolean isNameAgree,
+
+            //카카오계정 이름
+            @JsonProperty("name")
+            String name,
+
+            //이메일 제공 동의 여부
+            @JsonProperty("email_needs_agreement")
+            Boolean isEmailAgree,
+
+            //이메일이 유효 여부
+            // true : 유효한 이메일, false : 이메일이 다른 카카오 계정에 사용돼 만료
+            @JsonProperty("is_email_valid")
+            Boolean isEmailValid,
+
+            //이메일이 인증 여부
+            //true : 인증된 이메일, false : 인증되지 않은 이메일
+            @JsonProperty("is_email_verified")
+            Boolean isEmailVerified,
+
+            //카카오계정 대표 이메일
+            @JsonProperty("email")
+            String email,
+
+            //연령대 제공 동의 여부
+            @JsonProperty("age_range_needs_agreement")
+            Boolean isAgeAgree,
+
+            //연령대
+            //참고 https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+            @JsonProperty("age_range")
+            String ageRange,
+
+            //출생 연도 제공 동의 여부
+            @JsonProperty("birthyear_needs_agreement")
+            Boolean isBirthYearAgree,
+
+            //출생 연도 (YYYY 형식)
+            @JsonProperty("birthyear")
+            String birthYear,
+
+            //생일 제공 동의 여부
+            @JsonProperty("birthday_needs_agreement")
+            Boolean isBirthDayAgree,
+
+            //생일 (MMDD 형식)
+            @JsonProperty("birthday")
+            String birthDay,
+
+            //생일 타입
+            // SOLAR(양력) 혹은 LUNAR(음력)
+            @JsonProperty("birthday_type")
+            String birthDayType,
+
+            //성별 제공 동의 여부
+            @JsonProperty("gender_needs_agreement")
+            Boolean isGenderAgree,
+
+            //성별
+            @JsonProperty("gender")
+            String gender,
+
+            //전화번호 제공 동의 여부
+            @JsonProperty("phone_number_needs_agreement")
+            Boolean isPhoneNumberAgree,
+
+            //전화번호
+            //국내 번호인 경우 +82 00-0000-0000 형식
+            @JsonProperty("phone_number")
+            String phoneNumber,
+
+            //CI 동의 여부
+            @JsonProperty("ci_needs_agreement")
+            Boolean isCIAgree,
+
+            //CI, 연계 정보
+            @JsonProperty("ci")
+            String ci,
+
+            //CI 발급 시각, UTC
+            @JsonProperty("ci_authenticated_at")
+            Date ciCreatedAt
+    ) {
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public record Profile(
+                //닉네임
+                @JsonProperty("nickname")
+                String nickName,
+
+                //프로필 미리보기 이미지 URL
+                @JsonProperty("thumbnail_image_url")
+                String thumbnailImageUrl,
+
+                //프로필 사진 URL
+                @JsonProperty("profile_image_url")
+                String profileImageUrl,
+
+                //프로필 사진 URL 기본 프로필인지 여부
+                //true : 기본 프로필, false : 사용자 등록
+                @JsonProperty("is_default_image")
+                String isDefaultImage,
+
+                //닉네임이 기본 닉네임인지 여부
+                //true : 기본 닉네임, false : 사용자 등록
+                @JsonProperty("is_default_nickname")
+                Boolean isDefaultNickName
+        ) {
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Partner(
+            //고유 ID
+            @JsonProperty("uuid")
+            String uuid
+    ) {
+    }
+}

--- a/src/main/java/com/project/likelion13th_team1/global/security/kakao/service/KakaoService.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/kakao/service/KakaoService.java
@@ -1,0 +1,93 @@
+package com.project.likelion13th_team1.global.security.kakao.service;
+
+import com.project.likelion13th_team1.domain.member.repository.MemberRepository;
+import com.project.likelion13th_team1.global.security.jwt.JwtUtil;
+import com.project.likelion13th_team1.global.security.kakao.dto.response.KakaoTokenResponseDto;
+import com.project.likelion13th_team1.global.security.kakao.dto.response.KakaoUserInfoResponseDto;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+public class KakaoService {
+
+
+    private final String clientId;     // API Key
+    private final String tokenURI;    // 카카오 인증 서버
+    private final String userInfoURI;     // 카카오 리소스 서버
+    private final String redirectURI;  // redirect URI
+    private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
+
+    @Autowired
+    public KakaoService(@Value("${spring.security.oauth2.client.registration.kakao.client-id}") String clientId,
+                        @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}") String redirectURI,
+                        @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}") String userInfoURI,
+                        @Value("${spring.security.oauth2.client.provider.kakao.token-uri}") String tokenURI, MemberRepository memberRepository, JwtUtil jwtUtil) {
+        this.clientId = clientId;
+        this.tokenURI = tokenURI;
+        this.userInfoURI = userInfoURI;
+        this.redirectURI = redirectURI;
+        this.memberRepository = memberRepository;
+        this.jwtUtil = jwtUtil;
+    }
+
+    public String getAccessTokenFromKakao(String code) {
+
+        KakaoTokenResponseDto kakaoTokenResDto = WebClient.create(tokenURI)
+                .post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", clientId)
+                        .queryParam("redirect_uri", redirectURI)
+                        .queryParam("code", code)
+                        .build(true))
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                //TODO : Custom Exception
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .bodyToMono(KakaoTokenResponseDto.class)
+                .block();
+
+
+        log.info(" [Kakao Service] Access Token ------> {}", kakaoTokenResDto.accessToken());
+        log.info(" [Kakao Service] Refresh Token ------> {}", kakaoTokenResDto.refreshToken());
+        //제공 조건: OpenID Connect가 활성화 된 앱의 토큰 발급 요청인 경우 또는 scope에 openid를 포함한 추가 항목 동의 받기 요청을 거친 토큰 발급 요청인 경우
+        log.info(" [Kakao Service] Id Token ------> {}", kakaoTokenResDto.idToken());
+        log.info(" [Kakao Service] Scope ------> {}", kakaoTokenResDto.scope());
+
+        return kakaoTokenResDto.accessToken();
+    }
+
+    public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
+
+        KakaoUserInfoResponseDto userInfo = WebClient.create(userInfoURI)
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .build(true))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                //TODO : Custom Exception
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .bodyToMono(KakaoUserInfoResponseDto.class)
+                .block();
+
+        log.info("[ Kakao Service ] Auth ID ---> {} ", userInfo.id());
+        log.info("[ Kakao Service ] NickName ---> {} ", userInfo.kakaoAccount().profile().nickName());
+        log.info("[ Kakao Service ] ProfileImageUrl ---> {} ", userInfo.kakaoAccount().profile().profileImageUrl());
+
+        return userInfo;
+    }
+}

--- a/src/main/java/com/project/likelion13th_team1/global/security/userdetails/service/CustomUserDetailsService.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/userdetails/service/CustomUserDetailsService.java
@@ -16,8 +16,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -31,12 +29,12 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
         log.info("[ CustomUserDetailsService ] Email 을 이용하여 User 를 검색합니다.");
-        Member member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
         log.info("[ CustomUserDetailsService ] Member 를 이용하여 Auth 를 검색합니다.");
         Auth auth = authRepository.findByMember(member)
                 .orElseThrow(() -> new AuthException(AuthErrorCode._NOT_FOUND));
-//        Optional<Member> memberEntity = memberRepository.findByEmail(email);
+//        Optional<Member> memberEntity = memberRepository.findByEmailAndNotDeleted(email);
 //        if (memberEntity.isPresent()) {
 //            Member member = memberEntity.get();
 //            return new CustomUserDetails(member.getEmail(),member.getPassword(), member.getRole());

--- a/src/main/java/com/project/likelion13th_team1/global/security/userdetails/service/CustomUserDetailsService.java
+++ b/src/main/java/com/project/likelion13th_team1/global/security/userdetails/service/CustomUserDetailsService.java
@@ -4,6 +4,10 @@ import com.project.likelion13th_team1.domain.member.entity.Member;
 import com.project.likelion13th_team1.domain.member.exception.MemberErrorCode;
 import com.project.likelion13th_team1.domain.member.exception.MemberException;
 import com.project.likelion13th_team1.domain.member.repository.MemberRepository;
+import com.project.likelion13th_team1.global.security.auth.entity.Auth;
+import com.project.likelion13th_team1.global.security.auth.repository.AuthRepository;
+import com.project.likelion13th_team1.global.security.exception.AuthErrorCode;
+import com.project.likelion13th_team1.global.security.exception.AuthException;
 import com.project.likelion13th_team1.global.security.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,17 +24,24 @@ import java.util.Optional;
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
+    private final AuthRepository authRepository;
 
     //Username(Email) 로 CustomUserDetail 을 가져오기
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
         log.info("[ CustomUserDetailsService ] Email 을 이용하여 User 를 검색합니다.");
-        Optional<Member> memberEntity = memberRepository.findByEmail(email);
-        if (memberEntity.isPresent()) {
-            Member member = memberEntity.get();
-            return new CustomUserDetails(member.getEmail(),member.getPassword(), member.getRole());
-        }
-        throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        log.info("[ CustomUserDetailsService ] Member 를 이용하여 Auth 를 검색합니다.");
+        Auth auth = authRepository.findByMember(member)
+                .orElseThrow(() -> new AuthException(AuthErrorCode._NOT_FOUND));
+//        Optional<Member> memberEntity = memberRepository.findByEmail(email);
+//        if (memberEntity.isPresent()) {
+//            Member member = memberEntity.get();
+//            return new CustomUserDetails(member.getEmail(),member.getPassword(), member.getRole());
+//        }
+//        throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);
+        return new CustomUserDetails(member.getEmail(), auth.getPassword(), member.getRole());
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,3 +25,23 @@ spring:
     token:
       access-expiration-time: ${JWT_ACCESS_EXPIRATION_TIME}
       refresh-expiration-time: ${JWT_REFRESH_EXPIRATION_TIME}
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            authorization-grant-type: ${KAKAO_AUTHORIZATION_GRANT_TYPE}
+            client-id: ${KAKAO_CLIENT_ID}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            client-authentication-method: ${KAKAO_AUTHENTICATION_METHOD}
+            scope:
+              - profile_nickname
+              - profile_image
+              - profile_email
+        provider:
+          kakao:
+            authorization-uri: ${KAKAO_AUTHORIZATION_URI}
+            token-uri: ${KAKAO_TOKEN_URI}
+            user-info-uri: ${KAKAO_USER_INFO_URI}
+            user-name-attribute: ${KAKAO_USER_NAME_ATTRIBUTE}


### PR DESCRIPTION
# ☝️Issue Number

- #14 

##  📌 개요

- 카카오 로그인 구현
- 비밀번호 저장 엔티티 분리
- 로컬 -> member + auth
- 소셜 -> member + socialLogin
- 개발을 위한 meber soft delete -> hard delete

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점