### PR TITLE
Feat/#8-6: 루틴 추천 구현

### DIFF
--- a/src/main/java/com/project/likelion13th_team1/domain/feature/converter/FeatureConverter.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/feature/converter/FeatureConverter.java
@@ -4,6 +4,7 @@ import com.project.likelion13th_team1.domain.feature.dto.request.FeatureRequestD
 import com.project.likelion13th_team1.domain.feature.dto.response.FeatureResponseDto;
 import com.project.likelion13th_team1.domain.feature.entity.Feature;
 import com.project.likelion13th_team1.domain.member.entity.Member;
+import com.project.likelion13th_team1.domain.member.entity.Personality;
 
 public class FeatureConverter {
 
@@ -17,7 +18,7 @@ public class FeatureConverter {
                 .build();
     }
 
-    public static FeatureResponseDto.FeatureDetailResponseDto toFeatureDetailResponseDto(Feature feature) {
+    public static FeatureResponseDto.FeatureDetailResponseDto toFeatureDetailResponseDto(Feature feature, Personality personality) {
         return FeatureResponseDto.FeatureDetailResponseDto.builder()
                 .featureId(feature.getId())
                 .q1(feature.getQ1())
@@ -25,6 +26,7 @@ public class FeatureConverter {
                 .q3(feature.getQ3())
                 .q4(feature.getQ4())
                 .total(getTotal(feature))
+                .personality(personality)
                 .build();
     }
 

--- a/src/main/java/com/project/likelion13th_team1/domain/feature/dto/response/FeatureResponseDto.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/feature/dto/response/FeatureResponseDto.java
@@ -1,5 +1,6 @@
 package com.project.likelion13th_team1.domain.feature.dto.response;
 
+import com.project.likelion13th_team1.domain.member.entity.Personality;
 import lombok.Builder;
 
 public class FeatureResponseDto {
@@ -11,7 +12,8 @@ public class FeatureResponseDto {
             Integer q2,
             Integer q3,
             Integer q4,
-            Integer total
+            Integer total,
+            Personality personality
     ) {
     }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/feature/entity/Feature.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/feature/entity/Feature.java
@@ -52,4 +52,8 @@ public class Feature {
     public void updateQ4(Integer q4) {
         this.q4 = q4;
     }
+
+    public Integer getTotal() {
+        return this.q1 + this.q2 + this.q3 + this.q4;
+    }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/feature/service/command/FeatureCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/feature/service/command/FeatureCommandServiceImpl.java
@@ -2,6 +2,7 @@ package com.project.likelion13th_team1.domain.feature.service.command;
 
 import com.project.likelion13th_team1.domain.feature.dto.response.FeatureResponseDto;
 import com.project.likelion13th_team1.domain.member.entity.Member;
+import com.project.likelion13th_team1.domain.member.entity.Personality;
 import com.project.likelion13th_team1.domain.member.exception.MemberErrorCode;
 import com.project.likelion13th_team1.domain.member.exception.MemberException;
 import com.project.likelion13th_team1.domain.member.repository.MemberRepository;
@@ -11,6 +12,7 @@ import com.project.likelion13th_team1.domain.feature.entity.Feature;
 import com.project.likelion13th_team1.domain.feature.exception.FeatureErrorCode;
 import com.project.likelion13th_team1.domain.feature.exception.FeatureException;
 import com.project.likelion13th_team1.domain.feature.repository.FeatureRepository;
+import com.project.likelion13th_team1.domain.member.service.command.MemberCommandService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -25,6 +27,7 @@ public class FeatureCommandServiceImpl implements FeatureCommandService {
 
     private final MemberRepository memberRepository;
     private final FeatureRepository featureRepository;
+    private final MemberCommandService memberCommandService;
 
     @Override
     public void createFeature(String email, FeatureRequestDto.FeatureCreateRequestDto featureCreateRequestDto) {
@@ -38,9 +41,8 @@ public class FeatureCommandServiceImpl implements FeatureCommandService {
         } catch (DataIntegrityViolationException e){
             throw new FeatureException(FeatureErrorCode.FEATURE_DUPLICATED);
         }
-
-
-        member.linkFeature(feature);
+        // 특성 값 저장
+        memberCommandService.updatePersonality(member, Personality.fromScore(feature.getTotal()));
     }
 
     @Override
@@ -56,6 +58,6 @@ public class FeatureCommandServiceImpl implements FeatureCommandService {
         if (featureUpdateRequestDto.q3() != null) feature.updateQ3(featureUpdateRequestDto.q3());
         if (featureUpdateRequestDto.q4() != null) feature.updateQ4(featureUpdateRequestDto.q4());
 
-
+        memberCommandService.updatePersonality(member, Personality.fromScore(feature.getTotal()));
     }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/feature/service/query/FeatureQueryServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/feature/service/query/FeatureQueryServiceImpl.java
@@ -29,6 +29,6 @@ public class FeatureQueryServiceImpl implements FeatureQueryService {
 
         Feature feature = featureRepository.findByMember(member)
                 .orElseThrow(() -> new FeatureException(FeatureErrorCode.FEATURE_NOT_FOUND));
-        return FeatureConverter.toFeatureDetailResponseDto(feature);
+        return FeatureConverter.toFeatureDetailResponseDto(feature, member.getPersonality());
     }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/group/controller/GroupController.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/group/controller/GroupController.java
@@ -71,4 +71,14 @@ public class GroupController {
         groupCommandService.deleteGroup(customUserDetails.getUsername(), groupId);
         return CustomResponse.onSuccess(HttpStatus.NO_CONTENT, "그룹 삭제 완료");
     }
+
+    @Operation(summary = "루틴 추천 그룹 생성", description = "멤버와 루틴의 특성 정보를 매칭시켜 루틴을 추천한다")
+    @PostMapping("/groups/{groupId}/recommendation")
+    public CustomResponse<String> recommendRoutineGroup(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long groupId
+    ) {
+        groupCommandService.createRecommendedRoutineGroup(customUserDetails.getUsername(), groupId);
+        return CustomResponse.onSuccess(HttpStatus.OK, "추천 루틴 그룹 저장 완료");
+    }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/group/exception/GroupErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum GroupErrorCode implements BaseErrorCode {
 
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404", "그룹을 찾을 수 없습니다."),
+    GROUP_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "GROUP409", "그룹 최대 생성 개수를 초과했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/project/likelion13th_team1/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/group/repository/GroupRepository.java
@@ -2,6 +2,7 @@ package com.project.likelion13th_team1.domain.group.repository;
 
 import com.project.likelion13th_team1.domain.group.dto.GroupDto;
 import com.project.likelion13th_team1.domain.group.entity.Group;
+import com.project.likelion13th_team1.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,4 +20,6 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             @Param("cursor") Long cursor,
             Pageable pageable
     );
+
+    Long countByMember(Member member);
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/group/service/command/GroupCommandService.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/group/service/command/GroupCommandService.java
@@ -11,4 +11,6 @@ public interface GroupCommandService {
 
     void deleteGroup(String email, Long groupId);
 
+    void createRecommendedRoutineGroup(String email, Long groupId);
+
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/group/service/command/GroupCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/group/service/command/GroupCommandServiceImpl.java
@@ -46,10 +46,14 @@ public class GroupCommandServiceImpl implements GroupCommandService {
 
     @Override
     public GroupResponseDto.GroupCreateResponseDto createGroup(String email, GroupRequestDto.GroupCreateRequestDto groupCreateRequestDto) {
-        LocalDate startAt = LocalDate.now();
-
         Member member = memberRepository.findByEmailAndNotDeleted(email)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Long groupCount = groupRepository.countByMember(member);
+
+        if (groupCount == 3) {
+            throw new GroupException(GroupErrorCode.GROUP_LIMIT_EXCEEDED);
+        }
 
         Group group = GroupConverter.toGroup(groupCreateRequestDto, member);
 

--- a/src/main/java/com/project/likelion13th_team1/domain/member/entity/Member.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/entity/Member.java
@@ -50,6 +50,10 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
 
+    @Column(name = "personality")
+    @Enumerated(EnumType.STRING)
+    private Personality personality;
+
     // soft delete 여부
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
@@ -79,5 +83,10 @@ public class Member extends BaseEntity {
     // member soft delete 메서드
     public void delete() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    // member personality update
+    public void updatePersonality(Personality personality) {
+        this.personality = personality;
     }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/member/entity/Personality.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/entity/Personality.java
@@ -3,9 +3,9 @@ package com.project.likelion13th_team1.domain.member.entity;
 import java.util.Arrays;
 
 public enum Personality {
-    LAZY(0, 3),
-    NORMAL(4, 6),
-    DILIGENT(7, Integer.MAX_VALUE);
+    LAZY(4, 6),
+    NORMAL(7, 9),
+    DILIGENT(10, 12);
 
     private final int min;
     private final int max;

--- a/src/main/java/com/project/likelion13th_team1/domain/member/entity/Personality.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/entity/Personality.java
@@ -1,0 +1,24 @@
+package com.project.likelion13th_team1.domain.member.entity;
+
+import java.util.Arrays;
+
+public enum Personality {
+    LAZY(0, 3),
+    NORMAL(4, 6),
+    DILIGENT(7, Integer.MAX_VALUE);
+
+    private final int min;
+    private final int max;
+
+    Personality(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public static Personality fromScore(int score) {
+        return Arrays.stream(values())
+                .filter(p -> score >= p.min && score <= p.max)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid score: " + score));
+    }
+}

--- a/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandService.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandService.java
@@ -1,6 +1,9 @@
 package com.project.likelion13th_team1.domain.member.service.command;
 
+import com.project.likelion13th_team1.domain.feature.entity.Feature;
 import com.project.likelion13th_team1.domain.member.dto.request.MemberRequestDto;
+import com.project.likelion13th_team1.domain.member.entity.Member;
+import com.project.likelion13th_team1.domain.member.entity.Personality;
 
 public interface MemberCommandService {
     void createLocalMember(MemberRequestDto.MemberCreateRequestDto memberCreateRequestDto);
@@ -11,4 +14,5 @@ public interface MemberCommandService {
 
     void deleteMember(String email);
 
+    void updatePersonality(Member member, Personality personality);
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/member/service/command/MemberCommandServiceImpl.java
@@ -1,9 +1,11 @@
 package com.project.likelion13th_team1.domain.member.service.command;
 
+import com.project.likelion13th_team1.domain.feature.entity.Feature;
 import com.project.likelion13th_team1.domain.member.converter.MemberConverter;
 import com.project.likelion13th_team1.domain.member.converter.SocialLoginConverter;
 import com.project.likelion13th_team1.domain.member.dto.request.MemberRequestDto;
 import com.project.likelion13th_team1.domain.member.entity.Member;
+import com.project.likelion13th_team1.domain.member.entity.Personality;
 import com.project.likelion13th_team1.domain.member.entity.SocialLogin;
 import com.project.likelion13th_team1.domain.member.exception.MemberErrorCode;
 import com.project.likelion13th_team1.domain.member.exception.MemberException;
@@ -72,5 +74,10 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 //        // soft delete
 //        member.delete();
         memberRepository.delete(member);
+    }
+
+    @Override
+    public void updatePersonality(Member member, Personality personality) {
+        member.updatePersonality(personality);
     }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/routine/controller/RoutineController.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/routine/controller/RoutineController.java
@@ -107,10 +107,4 @@ public class RoutineController {
         routineCommandService.inactivateRoutine(customUserDetails.getUsername(), routineId);
         return CustomResponse.onSuccess(HttpStatus.OK, "루틴비활성화 완료");
     }
-
-    @Operation(summary = "루틴 추천", description = "멤버와 루틴의 특성 정보를 매칭시켜 루틴을 추천한다")
-    @PostMapping("/routines/recommendation")
-    public CustomResponse<?> recommendRoutine() {
-        return CustomResponse.onFailure("500", "구상을 해봐야 해요", null);
-    }
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/routine/converter/RoutineConverter.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/routine/converter/RoutineConverter.java
@@ -5,10 +5,7 @@ import com.project.likelion13th_team1.domain.member.entity.Member;
 import com.project.likelion13th_team1.domain.routine.dto.RoutineDto;
 import com.project.likelion13th_team1.domain.routine.dto.request.RoutineRequestDto;
 import com.project.likelion13th_team1.domain.routine.dto.response.RoutineResponseDto;
-import com.project.likelion13th_team1.domain.routine.entity.Cycle;
-import com.project.likelion13th_team1.domain.routine.entity.ExampleRoutine;
-import com.project.likelion13th_team1.domain.routine.entity.Routine;
-import com.project.likelion13th_team1.domain.routine.entity.Type;
+import com.project.likelion13th_team1.domain.routine.entity.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -37,13 +34,27 @@ public class RoutineConverter {
         return Routine.builder()
                 .name(exampleRoutine.getName())
                 .description(exampleRoutine.getDescription())
-                .isActive(exampleRoutine.getIsActive())
+                .isActive(false)
                 .cycle(exampleRoutine.getCycle())
                 .startAt(LocalDate.now())
 //                .endAt(LocalDate.now().plusDays(5))
                 .group(group)
                 .build();
     }
+
+    public static Routine toRoutine(RecommendedRoutine recommendedRoutine, Group group) {
+        return Routine.builder()
+                .name(recommendedRoutine.getName())
+                .description(recommendedRoutine.getDescription())
+                .isActive(false)
+                .cycle(recommendedRoutine.getCycle())
+                .startAt(LocalDate.now())
+//                .startAt(startAt)
+                .endAt(LocalDate.now().plusMonths(3))
+                .group(group)
+                .build();
+    }
+
     public static RoutineResponseDto.RoutineCreateResponseDto toRoutineCreateResponseDto(Routine routine, Integer eventCount) {
         return RoutineResponseDto.RoutineCreateResponseDto.builder()
                 .routineId(routine.getId())

--- a/src/main/java/com/project/likelion13th_team1/domain/routine/entity/RecommendedRoutine.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/routine/entity/RecommendedRoutine.java
@@ -1,0 +1,39 @@
+package com.project.likelion13th_team1.domain.routine.entity;
+
+import com.project.likelion13th_team1.domain.member.entity.Personality;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "recommended_routine")
+public class RecommendedRoutine {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 루틴 이름
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    // 루틴 설명 (이게 뭐하는 루틴인지)
+    @Column(name = "description")
+    private String description;
+
+    // 사용 여부
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    // 반복 주기
+    @Column(name = "cycle", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Cycle cycle;
+
+    @Column(name = "personality", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Personality personality;
+}

--- a/src/main/java/com/project/likelion13th_team1/domain/routine/repository/RecommendedRoutineRepository.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/routine/repository/RecommendedRoutineRepository.java
@@ -1,0 +1,11 @@
+package com.project.likelion13th_team1.domain.routine.repository;
+
+import com.project.likelion13th_team1.domain.member.entity.Personality;
+import com.project.likelion13th_team1.domain.routine.entity.RecommendedRoutine;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RecommendedRoutineRepository extends JpaRepository<RecommendedRoutine, Long> {
+    List<RecommendedRoutine> findByPersonality(Personality personality);
+}

--- a/src/main/java/com/project/likelion13th_team1/domain/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/routine/repository/RoutineRepository.java
@@ -3,11 +3,15 @@ package com.project.likelion13th_team1.domain.routine.repository;
 import com.project.likelion13th_team1.domain.group.entity.Group;
 import com.project.likelion13th_team1.domain.routine.dto.RoutineDto;
 import com.project.likelion13th_team1.domain.routine.entity.Routine;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jdk.jfr.MetadataDefinition;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -47,4 +51,11 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
             "FROM Routine r " +
             "WHERE r.isActive = true")
     List<Routine> findAllActiveRoutines();
+
+    @Transactional
+    @Modifying
+    @Query("DELETE " +
+            "FROM Routine r " +
+            "WHERE r.group = :group")
+    void deleteByGroup(@Param("group") Group group);
 }

--- a/src/main/java/com/project/likelion13th_team1/domain/routine/service/command/RoutineCommandService.java
+++ b/src/main/java/com/project/likelion13th_team1/domain/routine/service/command/RoutineCommandService.java
@@ -1,9 +1,13 @@
 package com.project.likelion13th_team1.domain.routine.service.command;
 
 import com.project.likelion13th_team1.domain.group.entity.Group;
+import com.project.likelion13th_team1.domain.member.entity.Personality;
 import com.project.likelion13th_team1.domain.routine.dto.request.RoutineRequestDto;
 import com.project.likelion13th_team1.domain.routine.dto.response.RoutineResponseDto;
 import com.project.likelion13th_team1.domain.routine.entity.ExampleRoutine;
+import com.project.likelion13th_team1.domain.routine.entity.RecommendedRoutine;
+
+import java.util.List;
 
 public interface RoutineCommandService {
     RoutineResponseDto.RoutineCreateResponseDto createRoutine(Long groupId, RoutineRequestDto.RoutineCreateRequestDto routineCreateRequestDto);
@@ -17,4 +21,6 @@ public interface RoutineCommandService {
     void activateRoutine(String email, Long routineId);
 
     void inactivateRoutine(String email, Long routineId);
+
+    void createRecommendedRoutines(Personality personality, Group group);
 }


### PR DESCRIPTION
# ☝️Issue Number

- #

##  📌 개요

- 특성 생성이 된 경우 특성 생성을 했을 때 예외
- 그룹 생성시 기본적으로 존재하는 루틴 셋  (ExampleRoutine 구현)
- 루틴 목록 조회 업그레이드
- 특성 매핑 변경 (LAZY, NORMAL, DILIGENT)
- 루틴 추천 구현 (각각의 유저 특성(LAZY, NORMAL, DILIGENT) 마다 준비된 50개의 루틴 중에서 무작위로 20개 추출)
- 그룹 개수 생성 제한 3개

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점